### PR TITLE
ADD will unpack the mattermost-team-2.2.0-linux-amd64.tar.gz

### DIFF
--- a/mattermost/worker/Dockerfile
+++ b/mattermost/worker/Dockerfile
@@ -3,8 +3,7 @@
 FROM ubuntu:14.04
 
 # Copy over files
-ADD https://releases.mattermost.com/2.2.0/mattermost-team-2.2.0-linux-amd64.tar.gz /
-RUN cd /var && tar -zxvf /mattermost-team-2.2.0-linux-amd64.tar.gz && rm /mattermost-team-2.2.0-linux-amd64.tar.gz
+ADD https://releases.mattermost.com/2.2.0/mattermost-team-2.2.0-linux-amd64.tar.gz /var
 
 ADD docker-entry.sh /var/mattermost/bin/docker-entry.sh
 RUN chmod +x /var/mattermost/bin/docker-entry.sh


### PR DESCRIPTION
I was seeing the following error when trying to build using the older `Dockerfile`:
```
burdz@laptop:~/work/code/repos/quickstart/mattermost/worker$ docker build -t mattermost-worker:2.2.0 .                                                                                                     
Sending build context to Docker daemon  3.584kB                                                                                                                                                                    
Step 1/8 : FROM ubuntu:14.04                                                                                                                                                                                       
14.04: Pulling from library/ubuntu                                                                                                                                                                                 
7ee37f181318: Pull complete                                                                                                                                                                                        
df5ffabe5e97: Pull complete                                                                                                                                                                                        
ae2040ed51a1: Pull complete                                                                                                                                                                                        
3ce7010d244b: Pull complete                                                                                                                                                                                        
2538b201d2a6: Pull complete                                                                                                                                                                                        
Digest: sha256:13eecbc0e57928c1cb3ccca3581e2a6f4b0f39c1acf5a279e740e478accd119b                                                                                                                                    
Status: Downloaded newer image for ubuntu:14.04                                                                                                                                                                    
 ---> 54333f1de4ed                                                                                                                                                                                                 
Step 2/8 : ADD https://releases.mattermost.com/2.2.0/mattermost-team-2.2.0-linux-amd64.tar.gz /                                                                                                                    
Downloading  31.21MB/31.21MB                                                                                                                                                                                       
                                                                                                                                                                                                                   
 ---> 9d588e95ce75                                                                                                                                                                                                 
Removing intermediate container 4a003f36a651
Step 3/8 : RUN cd /var && tar -zxvf /mattermost-team-2.2.0-linux-amd64.tar.gz && rm /mattermost-team-2.2.0-linux-amd64.tar.gz
 ---> Running in 50e59a69cb5e
tar (child): /mattermost-team-2.2.0-linux-amd64.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

this is as `ADD` obeys the following rules:

```
If <src> is a local tar archive in a recognized compression format (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources from remote URLs are not decompressed. When a directory is copied or unpacked, it has the same behavior as tar -x, the result is the union of:

1. Whatever existed at the destination path and
2. The contents of the source tree, with conflicts resolved in favor of “2.” on a file-by-file basis.
```

REF: https://docs.docker.com/engine/reference/builder/#shell
