### PR TITLE
Update mattermost app.

### DIFF
--- a/mattermost/resources/app.yaml
+++ b/mattermost/resources/app.yaml
@@ -16,9 +16,7 @@ endpoints:
 providers:
   aws:
     regions:
-      - us-west-2
-      - us-east-1
-      - eu-central-1
+      - us-east-2
 installer:
   setupEndpoints:
     - "Setup"
@@ -26,12 +24,22 @@ installer:
     prompt: "How many nodes do you want?"
     items:
       - name: "single"
-        description: ""
+        description: "One node"
         nodes:
-          - profile: worker
+          - profile: node
             count: 1
+      - name: "double"
+        description: "Two-node cluster"
+        nodes:
+          - profile: node
+            count: 2
+      - name: "triple"
+        description: "Three-node cluster"
+        nodes:
+          - profile: node
+            count: 3
 nodeProfiles:
-  - name: worker
+  - name: node
     description: "Simple Mattermost Server"
     requirements:
       cpu:
@@ -41,10 +49,18 @@ nodeProfiles:
     providers:
       aws:
         instanceTypes:
-          - c3.4xlarge
+          - m4.xlarge
 hooks:
   install:
     job: file://install.yaml
+  clusterProvision:
+    job: file://clusterProvision.yaml
+  nodesProvision:
+    job: file://nodesProvision.yaml
+  nodesDeprovision:
+    job: file://nodesDeprovision.yaml
+  clusterDeprovision:
+    job: file://clusterDeprovision.yaml
 systemOptions:
   docker:
     storageDriver: overlay2

--- a/mattermost/resources/charts/mattermost/templates/mattermost.yaml
+++ b/mattermost/resources/charts/mattermost/templates/mattermost.yaml
@@ -139,23 +139,32 @@ spec:
 ---
 # mattermost postgres worker
 apiVersion: v1
-kind: Pod
+kind: ReplicationController
 metadata:
   name: mattermost-database
+  namespace: default
   labels:
     app: mattermost
     role: mattermost-database
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}    
-  namespace: default
+    heritage: {{ .Release.Service }}
 spec:
-  containers:
-  - name: mattermost-postgres
-    securityContext:
-      runAsUser: 0
-    image: {{.Values.registry}}postgres:9.4.4
-    ports:
-      - containerPort: 5432
+  replicas: 1
+  selector:
+    role: mattermost-database
+  template:
+    metadata:
+      labels:
+        app: mattermost
+        role: mattermost-database
+    spec:
+      containers:
+      - name: mattermost-postgres
+        securityContext:
+          runAsUser: 0
+        image: {{.Values.registry}}postgres:9.4.4
+        ports:
+        - containerPort: 5432
 ---
 # mattermost worker
 apiVersion: extensions/v1beta1
@@ -165,11 +174,11 @@ metadata:
     app: mattermost
     role: mattermost-worker
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}    
+    heritage: {{ .Release.Service }}
   name: mattermost-worker
   namespace: default
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       role: mattermost-worker

--- a/mattermost/resources/clusterDeprovision.yaml
+++ b/mattermost/resources/clusterDeprovision.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-deprovision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: cluster-deprovision
+        image: quay.io/gravitational/provisioner:ci.82
+        imagePullPolicy: Always
+        args: ['cluster-deprovision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/mattermost/resources/clusterProvision.yaml
+++ b/mattermost/resources/clusterProvision.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-provision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: cluster-provision
+        image: quay.io/gravitational/provisioner:ci.82
+        imagePullPolicy: Always
+        args: ['cluster-provision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/mattermost/resources/nodesDeprovision.yaml
+++ b/mattermost/resources/nodesDeprovision.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nodes-deprovision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: nodes-deprovision
+        image: quay.io/gravitational/provisioner:ci.82
+        imagePullPolicy: Always
+        args: ['nodes-deprovision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/mattermost/resources/nodesProvision.yaml
+++ b/mattermost/resources/nodesProvision.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nodes-provision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: nodes-provision
+        image: quay.io/gravitational/provisioner:ci.82
+        imagePullPolicy: Always
+        args: ['nodes-provision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/opscenter/terraform/opscenter.tf
+++ b/opscenter/terraform/opscenter.tf
@@ -2,7 +2,7 @@ variable "key_pair" {}
 variable "provisioning_token" {}
 
 variable "advertise_addr" {
-    description = "format: <hostname>:<https-port>,<ssh-port>, e.g. example.com:443,33008"
+    description = "format: <hostname>:<port>, e.g. example.com:443"
 }
 
 variable "region" {


### PR DESCRIPTION
Update it for 5LTS release.

* Update manifest to make sure provisioner works with it, add more flavors, etc.
* Use RC instead of a Pod for the database.

I've verified that it can now be installed fine (it used to fail on resources parsing b/c of all Helm resources).