### PR TITLE
Replace `latest` tag with `buster`.

### DIFF
--- a/mattermost/worker/Dockerfile
+++ b/mattermost/worker/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
 # See License.txt for license information.
-FROM quay.io/gravitational/debian-grande:latest
+FROM quay.io/gravitational/debian-grande:buster
 
 # Copy over files
 RUN apt-get update


### PR DESCRIPTION
`latest` tag is considered as anti-pattern. We should avoid using it.